### PR TITLE
Add offline temporal smoothing for YOLO pose overlays

### DIFF
--- a/Sports/README-temporal-pose-smoothing.md
+++ b/Sports/README-temporal-pose-smoothing.md
@@ -1,0 +1,18 @@
+# Temporal pose smoothing (recorded video)
+
+YOLO pose (and the DeadLift overlay notebook) draws **per-frame** keypoints.
+That is the source of overlay jitter — not a bad weight, and not a live-stream
+requirement.
+
+For **offline** clips, run detection on every frame, interpolate short gaps,
+then Savitzky–Golay each coordinate:
+
+```python
+from temporal_pose_smoothing import smooth_pose_tracks
+sm, vis = smooth_pose_tracks(xy, conf)  # xy: (T, 17, 2)
+```
+
+Causal One-Euro is the realtime alternative; it still lags. Two-pass Savgol is
+what you want for a 10s analysis render.
+
+Requires: `numpy`, `scipy`.

--- a/Sports/temporal_pose_smoothing.py
+++ b/Sports/temporal_pose_smoothing.py
@@ -1,0 +1,64 @@
+"""Offline temporal smoothing for YOLO/COCO-17 pose tracks.
+
+Per-frame pose models (including YOLO11-pose) estimate each frame independently.
+Drawing those keypoints raw makes skeleton overlays jitter. For recorded video,
+interpolate short gaps then apply a Savitzky–Golay filter on each coordinate.
+
+This does not change the detector. It is a post-process for overlay/analysis.
+"""
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import savgol_filter
+
+N_KPT = 17
+
+
+def _interp_track(vals: np.ndarray, mask: np.ndarray, max_gap: int = 8) -> tuple[np.ndarray, np.ndarray]:
+    n = len(vals)
+    idx = np.flatnonzero(mask)
+    if idx.size == 0:
+        return vals.copy(), mask.copy()
+    filled = np.interp(np.arange(n), idx, vals[idx])
+    ok = mask.copy()
+    for i in range(n):
+        if mask[i]:
+            continue
+        left = idx[idx < i]
+        right = idx[idx > i]
+        if left.size and right.size and (right[0] - left[-1]) <= max_gap:
+            ok[i] = True
+        elif left.size and i - left[-1] <= max_gap // 2:
+            ok[i] = True
+        elif right.size and right[0] - i <= max_gap // 2:
+            ok[i] = True
+    return filled, ok
+
+
+def smooth_pose_tracks(
+    xy: np.ndarray,
+    conf: np.ndarray,
+    conf_thr: float = 0.28,
+    window: int = 15,
+    poly: int = 2,
+) -> tuple[np.ndarray, np.ndarray]:
+    """xy: (T, K, 2), conf: (T, K). Returns smoothed xy and visibility."""
+    t, k, _ = xy.shape
+    sm = np.zeros_like(xy, dtype=np.float32)
+    vis = np.zeros((t, k), dtype=bool)
+    w = window if window % 2 else window - 1
+    for j in range(k):
+        mask = conf[:, j] >= conf_thr
+        sx, okx = _interp_track(xy[:, j, 0], mask)
+        sy, oky = _interp_track(xy[:, j, 1], mask)
+        ok = okx & oky
+        ww = min(w, int(ok.sum()) | 1)
+        if ww >= poly + 3:
+            if ww % 2 == 0:
+                ww -= 1
+            sx = savgol_filter(sx, ww, poly, mode="interp")
+            sy = savgol_filter(sy, ww, poly, mode="interp")
+        sm[:, j, 0] = sx
+        sm[:, j, 1] = sy
+        vis[:, j] = ok
+    return sm, vis

--- a/Sports/test_temporal_pose_smoothing.py
+++ b/Sports/test_temporal_pose_smoothing.py
@@ -1,0 +1,22 @@
+import numpy as np
+from temporal_pose_smoothing import smooth_pose_tracks
+
+
+def test_constant_track_unchanged():
+    t = 30
+    xy = np.zeros((t, 17, 2), np.float32)
+    xy[:, 0] = [10.0, 20.0]
+    conf = np.ones((t, 17), np.float32)
+    sm, vis = smooth_pose_tracks(xy, conf, window=9)
+    assert vis[:, 0].all()
+    assert np.allclose(sm[:, 0, 0], 10.0, atol=0.05)
+
+
+def test_spike_is_damped():
+    t = 31
+    xy = np.zeros((t, 17, 2), np.float32)
+    xy[:, 5, 1] = 100.0
+    xy[15, 5, 1] = 180.0
+    conf = np.ones((t, 17), np.float32)
+    sm, _ = smooth_pose_tracks(xy, conf, window=11)
+    assert abs(sm[15, 5, 1] - 100.0) < abs(180.0 - 100.0) * 0.5


### PR DESCRIPTION
Fixes Labellerr/Hands-On-Learning-in-Computer-Vision#63

DeadLift.ipynb draws per-frame YOLO keypoints with no temporal filter, so skeleton overlays jitter. This is expected detector behavior, not a bad checkpoint.

Adds `Sports/temporal_pose_smoothing.py`: interpolate short gaps, Savitzky–Golay each coordinate. Optional for recorded video. Does not change the model.

Small tests in `Sports/test_temporal_pose_smoothing.py`.